### PR TITLE
Fixes events occuring all at once + major/moderate event failure spam at roundstart.

### DIFF
--- a/code/modules/unit_tests/~zubbers/predictable_storyteller.dm
+++ b/code/modules/unit_tests/~zubbers/predictable_storyteller.dm
@@ -1,19 +1,25 @@
 /datum/unit_test/predictable_storyteller
-	var/expected_result = 0.35
+	var/expected_result = 0.22
 
 /datum/unit_test/predictable_storyteller/Run()
 
 	var/datum/job/assistant_job = SSjob.GetJobType(/datum/job/assistant)
 	var/datum/job/head_of_security_job = SSjob.GetJobType(/datum/job/head_of_security)
+	var/datum/job/medical_job = SSjob.GetJobType(/datum/job/doctor)
+	var/datum/job/engineer_job = SSjob.GetJobType(/datum/job/station_engineer)
 
 	var/list/testing_minds = list()
-	for(var/i=1,i<=10,i++)
+	for(var/i=1,i<=20,i++)
 
 		var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
 		dummy.mind_initialize()
 
-		if(i<=2)
+		if(i<=2) //1 hos
 			dummy.mind.set_assigned_role(head_of_security_job)
+		else if(i == 4) //1 medical doctor
+			dummy.mind.set_assigned_role(medical_job)
+		else if(i == 6) //1 engineer
+			dummy.mind.set_assigned_role(engineer_job)
 		else
 			dummy.mind.set_assigned_role(assistant_job)
 

--- a/modular_zubbers/code/modules/storyteller/storytellers/storyteller_predictable.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/storyteller_predictable.dm
@@ -138,10 +138,13 @@
 
 		if(COOLDOWN_FINISHED(src,major_event_cooldown) && find_and_buy_event_from_track(EVENT_TRACK_MAJOR))
 			COOLDOWN_START(src, major_event_cooldown, major_event_delay)
+			COOLDOWN_START(src, moderate_event_cooldown, moderate_event_delay)
+			COOLDOWN_START(src, mundane_event_cooldown, mundane_event_delay)
 			return TRUE
 
 	if(COOLDOWN_FINISHED(src,moderate_event_cooldown) && find_and_buy_event_from_track(EVENT_TRACK_MODERATE))
 		COOLDOWN_START(src, moderate_event_cooldown, moderate_event_delay)
+		COOLDOWN_START(src, mundane_event_cooldown, mundane_event_delay)
 		return TRUE
 
 	if(COOLDOWN_FINISHED(src,mundane_event_cooldown) && find_and_buy_event_from_track(EVENT_TRACK_MUNDANE))

--- a/modular_zubbers/code/modules/storyteller/storytellers/storyteller_predictable.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/storyteller_predictable.dm
@@ -17,6 +17,22 @@
 
 	)
 
+	starting_point_multipliers = list(
+		EVENT_TRACK_MUNDANE = 2,
+		EVENT_TRACK_MODERATE = 2,
+		EVENT_TRACK_MAJOR = 2,
+		EVENT_TRACK_ROLESET = 2,
+		EVENT_TRACK_OBJECTIVES = 2
+	)
+
+	point_gains_multipliers = list(
+		EVENT_TRACK_MUNDANE = 2,
+		EVENT_TRACK_MODERATE = 2,
+		EVENT_TRACK_MAJOR = 2,
+		EVENT_TRACK_ROLESET = 2,
+		EVENT_TRACK_OBJECTIVES = 2
+	)
+
 	event_repetition_multiplier = 0.25 //Repeat events are boring.
 
 	var/last_crew_score = 0
@@ -35,10 +51,12 @@
 	reset_cooldowns()
 	. = ..()
 
+
 /datum/storyteller/predictable/proc/reset_cooldowns()
 	COOLDOWN_START(src, mundane_event_cooldown, mundane_event_delay)
-	COOLDOWN_START(src, moderate_event_cooldown, moderate_event_cooldown)
-	COOLDOWN_START(src, major_event_cooldown, major_event_cooldown)
+	COOLDOWN_START(src, moderate_event_cooldown, moderate_event_delay)
+	COOLDOWN_START(src, major_event_cooldown, major_event_delay)
+
 
 //IF YOU EDIT THIS PROC, REMEMBER TO ALSO EDIT THE UNIT TESTS IN unit_tests/zubbers/predictable_storyteller.dm
 /proc/storyteller_get_antag_to_crew_ratio(do_debug=FALSE,minds_to_use_override)
@@ -48,6 +66,9 @@
 
 	if(!minds_to_use_override)
 		minds_to_use_override = SSticker.minds
+
+	var/medical_count = 0
+	var/engineering_count = 0
 
 	for(var/datum/mind/mob_mind as anything in minds_to_use_override)
 
@@ -80,12 +101,28 @@
 					if(mob_mind.current && mob_mind.current.stat == DEAD)
 						crew_score *= -0.25 //If you're dead, then usually some chaos must be happening and you in fact are a slight burden towards the crew.
 					total_crew_score += crew_score
+					//Hacky nonsense here. Limits based on support roles.
+					//MEDICAL
+					if(current_job.supervisors == SUPERVISOR_CMO)
+						if(current_job.title == JOB_MEDICAL_DOCTOR)
+							medical_count += 1
+						else
+							medical_count += 0.5
+					//ENGINEERING
+					if(current_job.supervisors == SUPERVISOR_CE)
+						if(current_job.title == JOB_STATION_ENGINEER)
+							engineering_count += 1
+						else
+							engineering_count += 0.5
 
 		if(antagonist_score)
 			total_antagonist_score += antagonist_score
 
 	if(total_crew_score <= 0)
 		return INFINITY //Force infinity.
+
+	total_crew_score = total_crew_score*0.75 + min(total_crew_score*0.25,engineering_count*10) //Up to 25% penalty if there are no engineers.
+	total_crew_score = total_crew_score*0.25 + min(total_crew_score*0.75,medical_count*10) //Up to 75% penalty if there are no medical doctors.
 
 	return round(total_antagonist_score/total_crew_score,0.01)
 


### PR DESCRIPTION
Fixes an issue where storyteller would try to run a major and moderate event ASAP because of a typo.

Makes the storyteller consider the amount of medical doctors and engineers so there isn't high chaos with 0 doctors.